### PR TITLE
BlackHole checking for finished downloads + fix in general Mover

### DIFF
--- a/Mover/Mover.py
+++ b/Mover/Mover.py
@@ -25,7 +25,7 @@ import shutil
 
 
 class Mover(PostProcessor):
-    version = "0.1"
+    version = "0.2"
     identifier = 'de.lad1337.simple.mover'
     screenName = 'Mover'
     types = []
@@ -49,7 +49,7 @@ class Mover(PostProcessor):
         PostProcessor.__init__(self, instance=instance)
 
 
-    def _postProcessPath(self, element, srcPath):
+    def postProcessPath(self, element, srcPath):
         destPath = self._getPath(element)
         if self.c.copy:
             msg = "Copying %s to %s" % (srcPath, destPath)


### PR DESCRIPTION
Hi,

I updated the BlackHole downloader so it can check for finished downloads. Seems to work for me.
I also fixed the general Mover so that the postProcessPath method actually gets called.
Warning: I also changed the meta.json for testing...

Regards,
Jeroen
